### PR TITLE
Deserialize to UTC date

### DIFF
--- a/src/py_adapter/__init__.py
+++ b/src/py_adapter/__init__.py
@@ -457,7 +457,7 @@ class _ObjectAdapter(_Adapter):
         if isinstance(data, int):
             # Assume we have serialized as a timestamp in milliseconds. Now that is NOT how we would have serialized it
             # if it was Avro. So this is useful only in combination with serializing using ``datetime_type=int``.
-            return datetime.date.fromtimestamp(data / 1e3)
+            return datetime.datetime.fromtimestamp(data / 1e3, tz=datetime.timezone.utc).date()
         elif isinstance(data, str):
             return dateutil.parser.isoparse(data).date()
         else:


### PR DESCRIPTION
Parse int to to date via a timezone-aware UTC datetime rather than directly using `date.fromtimestamp()`, as the latter returns a date in the local timezone